### PR TITLE
Add recurring recurring event support

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -47,6 +47,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 import store
 from llm_provider import LLM
 from stt import STT
+from dateutil import rrule
 
 load_dotenv()
 
@@ -287,6 +288,28 @@ def schedule_event_if_due(ev: dict) -> None:
     )
 
 
+def schedule_recurring_event_if_due(ev: dict) -> None:
+    rrule_str = ev.get("rrule")
+    owner = ev.get("owner")
+    if not rrule_str or not owner:
+        return
+    try:
+        rule = rrule.rrulestr(rrule_str)
+        next_dt = rule.after(datetime.now(), inc=True)
+    except Exception:
+        return
+    if not next_dt or next_dt <= datetime.now():
+        return
+    scheduler.add_job(
+        send_event_reminder,
+        "date",
+        run_date=next_dt,
+        id=f"revent:{ev['id']}",
+        replace_existing=True,
+        args=[owner, ev["title"], next_dt.isoformat(), ev["id"][:8]],
+    )
+
+
 def schedule_reminder_if_due(rem: dict) -> None:
     at = rem.get("at")
     owner = rem.get("owner")
@@ -314,6 +337,8 @@ def rehydrate_all_jobs() -> None:
         schedule_task_if_due(t)
     for e in store.list_events():
         schedule_event_if_due(e)
+    for r in store.list_recurring_events():
+        schedule_recurring_event_if_due(r)
     for r in store.list_reminders():
         schedule_reminder_if_due(r)
 
@@ -339,6 +364,8 @@ HELP_TEXT = (
     "/event_move ID_PREFIX YYYY-MM-DDTHH:MM\n"
     "/event_duration ID_PREFIX МИНУТЫ\n"
     "/event_delete ID_PREFIX\n"
+    "/event_repeat \"Название\" каждый ПОНЕДЕЛЬНИК в HH[:MM] ДЛИТ_МИН\n"
+    "/event_repeat_delete ID_PREFIX\n"
     "/remind \"Текст\" YYYY-MM-DDTHH:MM\n"
     "/reminders\n"
     "/rem_del ID_PREFIX\n"
@@ -465,6 +492,65 @@ async def cmd_event_delete(message: Message, command: CommandObject) -> None:
     await message.answer(f"🗑 Удалено: [{ev['id'][:8]}] {ev['title']}")
 
 
+@dp.message(Command("event_repeat"))
+async def cmd_event_repeat(message: Message, command: CommandObject) -> None:
+    args = command.args or ""
+    pattern = (
+        r'"(.+?)"\s+каждый\s+'
+        r'(понедельник|вторник|среду|среда|четверг|пятницу|субботу|суббота|воскресенье)\s+'
+        r'в\s+(\d{1,2})(?::(\d{2}))?\s+(\d+)'
+    )
+    m = re.match(pattern, args.lower())
+    if not m:
+        await message.answer('Формат: /event_repeat "Название" каждый ПОНЕДЕЛЬНИК в HH[:MM] ДЛИТ_МИН')
+        return
+    title = m.group(1)
+    day = m.group(2)
+    hour = int(m.group(3))
+    minute = int(m.group(4) or 0)
+    duration = int(m.group(5))
+    weekday_map = {
+        "понедельник": rrule.MO,
+        "вторник": rrule.TU,
+        "среду": rrule.WE,
+        "среда": rrule.WE,
+        "четверг": rrule.TH,
+        "пятницу": rrule.FR,
+        "субботу": rrule.SA,
+        "суббота": rrule.SA,
+        "воскресенье": rrule.SU,
+    }
+    weekday = weekday_map[day]
+    now = datetime.now().replace(second=0, microsecond=0)
+    dt = now.replace(hour=hour, minute=minute)
+    while dt.weekday() != weekday.weekday or dt <= now:
+        dt += timedelta(days=1)
+    rule = rrule.rrule(rrule.WEEKLY, dtstart=dt, byweekday=weekday)
+    rrule_str = str(rule)
+    ev = store.add_recurring_event(title, rrule_str, duration, owner=message.chat.id)
+    schedule_recurring_event_if_due(ev)
+    await message.answer(
+        f"✅ Добавил повторяющееся событие [{ev['id'][:8]}] {title} — {day} в {hour:02d}:{minute:02d}"
+    )
+
+
+@dp.message(Command("event_repeat_delete"))
+async def cmd_event_repeat_delete(message: Message, command: CommandObject) -> None:
+    id8 = (command.args or "").strip()
+    if not id8:
+        await message.answer('Формат: /event_repeat_delete ID_PREFIX')
+        return
+    ev = store.delete_recurring_event(id8, owner=message.chat.id)
+    if not ev:
+        await message.answer("Серия не найдена ❌")
+        return
+    try:
+        scheduler.remove_job(f"revent:{ev['id']}")
+    except Exception:
+        pass
+    await message.answer(f"🗑 Серия удалена: [{ev['id'][:8]}] {ev['title']}")
+
+
 @dp.message(Command("agenda"))
 async def cmd_agenda(message: Message, command: CommandObject) -> None:
     arg = (command.args or "").strip().lower() or "today"
@@ -474,14 +560,16 @@ async def cmd_agenda(message: Message, command: CommandObject) -> None:
         date_str = (datetime.now() + timedelta(days=1)).date().isoformat()
     else:
         date_str = arg
-    events = [e for e in store.list_events(owner=message.chat.id) if e["start"].startswith(date_str)]
+    events = store.list_events_on(date_str, owner=message.chat.id)
     if not events:
         await message.answer(f"Событий на {date_str} нет.")
         return
     for e in events:
+        prefix = "🔁" if e.get("recurring") else "📅"
+        kb = None if e.get("recurring") else event_keyboard(e['id'][:8])
         await message.answer(
-            f"📅 [{e['id'][:8]}] {e['title']} — { _human(e['start']) } ({e['duration_min']} мин)",
-            reply_markup=event_keyboard(e['id'][:8]),
+            f"{prefix} [{e['id'][:8]}] {e['title']} — { _human(e['start']) } ({e['duration_min']} мин)",
+            reply_markup=kb,
         )
 
 

--- a/db.py
+++ b/db.py
@@ -49,6 +49,16 @@ def init_db() -> None:
             CREATE INDEX IF NOT EXISTS idx_events_owner ON events(owner);
             CREATE INDEX IF NOT EXISTS idx_events_start ON events(start);
 
+            CREATE TABLE IF NOT EXISTS recurring_events (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                rrule TEXT NOT NULL,
+                duration_min INTEGER NOT NULL,
+                owner INTEGER,
+                created_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_recurring_events_owner ON recurring_events(owner);
+
             CREATE TABLE IF NOT EXISTS reminders (
                 id TEXT PRIMARY KEY,
                 text TEXT NOT NULL,

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ vosk>=0.3.45           # Offline speech recognition engine (optional)
 # Additional libraries
 pytz>=2023.3           # Timezone handling (if needed)
 dateparser>=1.2.0      # Parsing natural language dates (optional, used by models)
+python-dateutil>=2.8.2 # Recurring event rules
 # Testing and linting
 pytest>=7.4.0
 flake8>=6.0.0

--- a/store.py
+++ b/store.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Optional
 from uuid import uuid4
 
+from dateutil.rrule import rrulestr
 from db import get_conn
 
 
@@ -237,6 +238,246 @@ def delete_event(
             (event["id"],),
         )
     return event
+
+
+# -----------------------------------------------------------------------------
+# Recurring events
+# -----------------------------------------------------------------------------
+
+
+def _recurring_event_from_row(row) -> Dict[str, object]:
+    return dict(row)
+
+
+def add_recurring_event(
+    title: str,
+    rrule_str: str,
+    duration_min: int = 60,
+    owner: Optional[int] = None,
+) -> Dict[str, object]:
+    rec_id = str(uuid4())
+    created_at = datetime.now().isoformat(timespec="seconds")
+    with get_conn() as conn:
+        conn.execute(
+            """
+            INSERT INTO recurring_events (id, title, rrule, duration_min, owner, created_at)
+            VALUES (?,?,?,?,?,?)
+            """,
+            (rec_id, title, rrule_str, int(duration_min), owner, created_at),
+        )
+        conn.execute(
+            "INSERT INTO search_index (id, type, content, owner) VALUES (?,?,?,?)",
+            (rec_id, "event", title, owner),
+        )
+    return {
+        "id": rec_id,
+        "title": title,
+        "rrule": rrule_str,
+        "duration_min": int(duration_min),
+        "owner": owner,
+        "created_at": created_at,
+    }
+
+
+def list_recurring_events(owner: Optional[int] = None) -> List[Dict[str, object]]:
+    sql = "SELECT * FROM recurring_events"
+    params: List[object] = []
+    if owner is not None:
+        sql += " WHERE owner = ?"
+        params.append(owner)
+    with get_conn() as conn:
+        rows = conn.execute(sql, params).fetchall()
+        return [_recurring_event_from_row(r) for r in rows]
+
+
+def get_recurring_event_by_prefix(
+    rec_id_prefix: str, owner: Optional[int] = None
+) -> Optional[Dict[str, object]]:
+    sql = "SELECT * FROM recurring_events WHERE id LIKE ? || '%'"
+    params: List[object] = [rec_id_prefix]
+    if owner is not None:
+        sql += " AND owner = ?"
+        params.append(owner)
+    with get_conn() as conn:
+        row = conn.execute(sql + " LIMIT 1", params).fetchone()
+        return _recurring_event_from_row(row) if row else None
+
+
+def update_recurring_event_title(
+    rec_id_prefix: str, new_title: str, owner: Optional[int] = None
+) -> Optional[Dict[str, object]]:
+    rec = get_recurring_event_by_prefix(rec_id_prefix, owner)
+    if not rec:
+        return None
+    with get_conn() as conn:
+        conn.execute(
+            "UPDATE recurring_events SET title = ? WHERE id = ?",
+            (new_title, rec["id"]),
+        )
+        conn.execute(
+            "UPDATE search_index SET content = ? WHERE id = ? AND type = 'event'",
+            (new_title, rec["id"]),
+        )
+    rec["title"] = new_title
+    return rec
+
+
+def update_recurring_event_rule(
+    rec_id_prefix: str, new_rrule: str, owner: Optional[int] = None
+) -> Optional[Dict[str, object]]:
+    rec = get_recurring_event_by_prefix(rec_id_prefix, owner)
+    if not rec:
+        return None
+    with get_conn() as conn:
+        conn.execute(
+            "UPDATE recurring_events SET rrule = ? WHERE id = ?",
+            (new_rrule, rec["id"]),
+        )
+    rec["rrule"] = new_rrule
+    return rec
+
+
+def delete_recurring_event(
+    rec_id_prefix: str, owner: Optional[int] = None
+) -> Optional[Dict[str, object]]:
+    rec = get_recurring_event_by_prefix(rec_id_prefix, owner)
+    if not rec:
+        return None
+    with get_conn() as conn:
+        conn.execute("DELETE FROM recurring_events WHERE id = ?", (rec["id"],))
+        conn.execute(
+            "DELETE FROM search_index WHERE id = ? AND type = 'event'",
+            (rec["id"],),
+        )
+    return rec
+
+
+def list_events_on(
+    day: str, owner: Optional[int] = None
+) -> List[Dict[str, object]]:
+    start = datetime.fromisoformat(day + "T00:00:00")
+    end = start + timedelta(days=1)
+    events = [
+        e
+        for e in list_events(owner)
+        if e.get("start", "").startswith(day)
+    ]
+    for rec in list_recurring_events(owner):
+        rule = rrulestr(rec["rrule"])
+        for dt in rule.between(start, end, inc=False):
+            events.append(
+                {
+                    "id": rec["id"],
+                    "title": rec["title"],
+                    "start": dt.isoformat(),
+                    "duration_min": rec["duration_min"],
+                    "owner": rec["owner"],
+                    "created_at": rec["created_at"],
+                    "recurring": True,
+                }
+            )
+    events.sort(key=lambda e: e["start"])
+    return events
+
+
+# -----------------------------------------------------------------------------
+# Reminders
+# -----------------------------------------------------------------------------
+
+
+def add_reminder(
+    text: str,
+    at_iso: str,
+    owner: Optional[int] = None,
+) -> Dict[str, object]:
+    rem_id = str(uuid4())
+    created_at = datetime.now().isoformat(timespec="seconds")
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO reminders (id, text, at, owner, created_at) VALUES (?,?,?,?,?)",
+            (rem_id, text, at_iso, owner, created_at),
+        )
+        conn.execute(
+            "INSERT INTO search_index (id, type, content, owner) VALUES (?,?,?,?)",
+            (rem_id, "reminder", text, owner),
+        )
+    return {
+        "id": rem_id,
+        "text": text,
+        "at": at_iso,
+        "owner": owner,
+        "created_at": created_at,
+    }
+
+
+def list_reminders(owner: Optional[int] = None) -> List[Dict[str, object]]:
+    sql = "SELECT * FROM reminders"
+    params: List[object] = []
+    if owner is not None:
+        sql += " WHERE owner = ?"
+        params.append(owner)
+    with get_conn() as conn:
+        rows = conn.execute(sql, params).fetchall()
+        return [dict(r) for r in rows]
+
+
+def get_reminder_by_prefix(
+    rem_id_prefix: str, owner: Optional[int] = None
+) -> Optional[Dict[str, object]]:
+    sql = "SELECT * FROM reminders WHERE id LIKE ? || '%'"
+    params: List[object] = [rem_id_prefix]
+    if owner is not None:
+        sql += " AND owner = ?"
+        params.append(owner)
+    with get_conn() as conn:
+        row = conn.execute(sql + " LIMIT 1", params).fetchone()
+        return dict(row) if row else None
+
+
+def snooze_reminder(
+    rem_id_prefix: str, minutes: int, owner: Optional[int] = None
+) -> Optional[Dict[str, object]]:
+    rem = get_reminder_by_prefix(rem_id_prefix, owner)
+    if not rem:
+        return None
+    base = datetime.fromisoformat(rem["at"])
+    new_at = (base + timedelta(minutes=minutes)).replace(microsecond=0).isoformat()
+    with get_conn() as conn:
+        conn.execute("UPDATE reminders SET at = ? WHERE id = ?", (new_at, rem["id"]))
+    rem["at"] = new_at
+    return rem
+
+
+def delete_reminder(
+    rem_id_prefix: str, owner: Optional[int] = None
+) -> Optional[Dict[str, object]]:
+    rem = get_reminder_by_prefix(rem_id_prefix, owner)
+    if not rem:
+        return None
+    with get_conn() as conn:
+        conn.execute("DELETE FROM reminders WHERE id = ?", (rem["id"],))
+        conn.execute(
+            "DELETE FROM search_index WHERE id = ? AND type = 'reminder'",
+            (rem["id"],),
+        )
+    return rem
+
+
+# -----------------------------------------------------------------------------
+# Search
+# -----------------------------------------------------------------------------
+
+
+def search_entries(query: str, owner: Optional[int] = None) -> List[Dict[str, object]]:
+    """Search tasks, events and reminders using FTS5."""
+    sql = "SELECT id, type, content, owner FROM search_index WHERE search_index MATCH ?"
+    params: List[object] = [query]
+    if owner is not None:
+        sql += " AND owner = ?"
+        params.append(owner)
+    with get_conn() as conn:
+        rows = conn.execute(sql, params).fetchall()
+        return [dict(r) for r in rows]
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,8 +1,12 @@
 import types
 from pathlib import Path
 import importlib
+import types
+from pathlib import Path
+import importlib
 import pytest
 import store
+import db
 
 
 class DummyMessage:
@@ -17,8 +21,14 @@ class DummyMessage:
 
 
 @pytest.fixture
-def bot_module(monkeypatch):
+def bot_module(monkeypatch, tmp_path):
     monkeypatch.setenv("TELEGRAM_TOKEN", "123:ABC")
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("STT_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.db")
+    db.init_db()
     import bot
     importlib.reload(bot)
     return bot

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,24 +1,25 @@
+import db
 import store
 from datetime import datetime, timedelta
+from dateutil.rrule import rrule, WEEKLY, MO
 
 
-def setup_store(tmp_path, monkeypatch):
-    monkeypatch.setattr(store, "DATA_DIR", tmp_path)
-    monkeypatch.setattr(store, "TASKS_PATH", tmp_path / "tasks.json")
-    monkeypatch.setattr(store, "EVENTS_PATH", tmp_path / "events.json")
-    monkeypatch.setattr(store, "REMINDERS_PATH", tmp_path / "reminders.json")
+def setup_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "test.db")
+    db.init_db()
 
 
 def test_tasks_flow(tmp_path, monkeypatch):
-    setup_store(tmp_path, monkeypatch)
+    setup_db(tmp_path, monkeypatch)
     t = store.add_task("test", None, owner=1)
-    assert store.list_tasks(owner=1) == [t]
+    tasks = store.list_tasks(owner=1)
+    assert tasks == [t]
     assert store.complete_task(t["id"][:8], owner=1)
     assert store.list_tasks(owner=1)[0]["done"] is True
 
 
 def test_events_and_reminders(tmp_path, monkeypatch):
-    setup_store(tmp_path, monkeypatch)
+    setup_db(tmp_path, monkeypatch)
     start = datetime.now().replace(microsecond=0).isoformat()
     ev = store.add_event("meet", start, 30, owner=1)
     assert store.snooze_event(ev["id"][:8], 10, owner=1)["start"]
@@ -30,3 +31,21 @@ def test_events_and_reminders(tmp_path, monkeypatch):
     assert store.snooze_reminder(rem["id"][:8], 5, owner=1)["at"]
     deleted_rem = store.delete_reminder(rem["id"][:8], owner=1)
     assert deleted_rem and deleted_rem["id"] == rem["id"]
+
+
+def test_recurring_events(tmp_path, monkeypatch):
+    setup_db(tmp_path, monkeypatch)
+    now = datetime.now().replace(second=0, microsecond=0)
+    # Next Monday 10:00
+    days_ahead = (0 - now.weekday()) % 7
+    dt = now + timedelta(days=days_ahead)
+    dt = dt.replace(hour=10, minute=0)
+    rule = rrule(WEEKLY, dtstart=dt, byweekday=MO)
+    rec = store.add_recurring_event("standup", str(rule), 15, owner=1)
+    day = dt.date().isoformat()
+    events = store.list_events_on(day, owner=1)
+    assert any(e.get("recurring") and e["title"] == "standup" for e in events)
+    deleted = store.delete_recurring_event(rec["id"][:8], owner=1)
+    assert deleted and deleted["id"] == rec["id"]
+    events = store.list_events_on(day, owner=1)
+    assert all(e["id"] != rec["id"] for e in events)

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -19,6 +19,7 @@ def test_pick_provider(monkeypatch, tmp_path):
         m.setenv("STT_PROVIDER", "auto")
         m.delenv("VOSK_MODEL_DIR", raising=False)
         m.setenv("OPENAI_API_KEY", "x")
+        m.setattr(stt.STT, "_ping_openai", lambda self: True)
         assert stt.STT().provider_in_use() == "openai"
 
 


### PR DESCRIPTION
## Summary
- add python-dateutil dependency and recurring_events table
- implement storing and expanding recurring event rules
- support /event_repeat command and show recurring instances in agenda
- test creation and cancellation of recurring events

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3819690b8833291d140ceb1f23ac0