### PR TITLE
Normalize timestamps to UTC and respect local timezones

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -30,6 +30,7 @@ import os
 import re
 import subprocess
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 from pathlib import Path
 from string import Template
 
@@ -49,6 +50,13 @@ from llm_provider import LLM
 from stt import STT
 
 load_dotenv()
+
+
+def _local_tz():
+    try:
+        return ZoneInfo("local")
+    except Exception:
+        return datetime.now().astimezone().tzinfo
 
 
 def _startup_checks() -> None:
@@ -110,7 +118,7 @@ bot = Bot(token=os.getenv("TELEGRAM_TOKEN"))
 dp = Dispatcher()
 llm = LLM()
 stt = STT()
-scheduler = AsyncIOScheduler()
+scheduler = AsyncIOScheduler(timezone=ZoneInfo("UTC"))
 
 
 # System prompt template for LLM
@@ -149,11 +157,12 @@ SYSTEM_PROMPT_TPL = """Ты помощник по расписанию и зад
 
 # Helper to humanise dates
 def _human(dt_iso: str) -> str:
+    tz = _local_tz()
     try:
-        dt = datetime.fromisoformat(dt_iso)
+        dt = datetime.fromisoformat(dt_iso).astimezone(tz)
     except Exception:
         return dt_iso
-    now = datetime.now()
+    now = datetime.now(tz=tz)
     if dt.date() == now.date():
         prefix = "сегодня"
     elif dt.date() == (now.date() + timedelta(days=1)):
@@ -251,10 +260,10 @@ def schedule_task_if_due(task: dict) -> None:
     if not due or not owner or task.get("done"):
         return
     try:
-        dt = datetime.fromisoformat(due)
+        dt = datetime.fromisoformat(due).astimezone(ZoneInfo("UTC"))
     except Exception:
         return
-    if dt <= datetime.now():
+    if dt <= datetime.now(tz=ZoneInfo("UTC")):
         return
     scheduler.add_job(
         send_task_reminder,
@@ -272,10 +281,10 @@ def schedule_event_if_due(ev: dict) -> None:
     if not start or not owner:
         return
     try:
-        dt = datetime.fromisoformat(start)
+        dt = datetime.fromisoformat(start).astimezone(ZoneInfo("UTC"))
     except Exception:
         return
-    if dt <= datetime.now():
+    if dt <= datetime.now(tz=ZoneInfo("UTC")):
         return
     scheduler.add_job(
         send_event_reminder,
@@ -293,10 +302,10 @@ def schedule_reminder_if_due(rem: dict) -> None:
     if not at or not owner:
         return
     try:
-        dt = datetime.fromisoformat(at)
+        dt = datetime.fromisoformat(at).astimezone(ZoneInfo("UTC"))
     except Exception:
         return
-    if dt <= datetime.now():
+    if dt <= datetime.now(tz=ZoneInfo("UTC")):
         return
     scheduler.add_job(
         send_reminder,
@@ -468,15 +477,24 @@ async def cmd_event_delete(message: Message, command: CommandObject) -> None:
 @dp.message(Command("agenda"))
 async def cmd_agenda(message: Message, command: CommandObject) -> None:
     arg = (command.args or "").strip().lower() or "today"
+    tz = _local_tz()
     if arg == "today":
-        date_str = datetime.now().date().isoformat()
+        target_date = datetime.now(tz=tz).date()
     elif arg == "tomorrow":
-        date_str = (datetime.now() + timedelta(days=1)).date().isoformat()
+        target_date = (datetime.now(tz=tz) + timedelta(days=1)).date()
     else:
-        date_str = arg
-    events = [e for e in store.list_events(owner=message.chat.id) if e["start"].startswith(date_str)]
+        try:
+            target_date = datetime.fromisoformat(arg).date()
+        except Exception:
+            await message.answer("Неверная дата")
+            return
+    events = [
+        e
+        for e in store.list_events(owner=message.chat.id)
+        if datetime.fromisoformat(e["start"]).astimezone(tz).date() == target_date
+    ]
     if not events:
-        await message.answer(f"Событий на {date_str} нет.")
+        await message.answer(f"Событий на {target_date.isoformat()} нет.")
         return
     for e in events:
         await message.answer(
@@ -599,23 +617,22 @@ async def process_free_text(message: Message, user_text: str) -> None:
         return
 
     # Build system prompt
-    now_iso = datetime.now().replace(microsecond=0).isoformat()
+    tz = _local_tz()
+    now = datetime.now(tz=tz)
+    now_iso = now.replace(microsecond=0).isoformat()
     tpl = Template(SYSTEM_PROMPT_TPL)
     sys_prompt = tpl.substitute(
         now_iso=now_iso,
         tomorrow_1800=(
-            datetime.now()
-            .replace(hour=18, minute=0, second=0, microsecond=0)
+            now.replace(hour=18, minute=0, second=0, microsecond=0)
             + timedelta(days=1)
         ).isoformat(),
         after_tomorrow_0930=(
-            datetime.now()
-            .replace(hour=9, minute=30, second=0, microsecond=0)
+            now.replace(hour=9, minute=30, second=0, microsecond=0)
             + timedelta(days=2)
         ).isoformat(),
         tomorrow_0900=(
-            datetime.now()
-            .replace(hour=9, minute=0, second=0, microsecond=0)
+            now.replace(hour=9, minute=0, second=0, microsecond=0)
             + timedelta(days=1)
         ).isoformat(),
     )

--- a/cli.py
+++ b/cli.py
@@ -22,6 +22,7 @@ import re
 import sys
 import threading
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 from string import Template
 from typing import Optional
 
@@ -37,6 +38,13 @@ import subprocess
 
 # Load environment variables from .env for local development
 load_dotenv()
+
+
+def _local_tz():
+    try:
+        return ZoneInfo("local")
+    except Exception:
+        return datetime.now().astimezone().tzinfo
 
 
 def _startup_checks() -> None:
@@ -72,7 +80,7 @@ console = Console()
 llm = LLM()
 
 # Background scheduler to deliver notifications to the console
-scheduler = BackgroundScheduler()
+scheduler = BackgroundScheduler(timezone=ZoneInfo("UTC"))
 
 # System prompt for LLM instructions, extended with examples
 SYSTEM_PROMPT_TPL = """Ты помощник по расписанию и задачам.
@@ -110,11 +118,12 @@ SYSTEM_PROMPT_TPL = """Ты помощник по расписанию и зад
 
 def _human(dt_iso: str) -> str:
     """Return a friendly representation of a datetime (relative today/tomorrow)."""
+    tz = _local_tz()
     try:
-        dt = datetime.fromisoformat(dt_iso)
+        dt = datetime.fromisoformat(dt_iso).astimezone(tz)
     except Exception:
         return dt_iso
-    now = datetime.now()
+    now = datetime.now(tz=tz)
     if dt.date() == now.date():
         prefix = "сегодня"
     elif dt.date() == (now.date() + timedelta(days=1)):
@@ -127,10 +136,10 @@ def _human(dt_iso: str) -> str:
 def schedule_console_notification(message: str, run_at_iso: str) -> None:
     """Schedule a console notification for the given time."""
     try:
-        dt = datetime.fromisoformat(run_at_iso)
+        dt = datetime.fromisoformat(run_at_iso).astimezone(ZoneInfo("UTC"))
     except Exception:
         return
-    if dt <= datetime.now():
+    if dt <= datetime.now(tz=ZoneInfo("UTC")):
         return
     def notify() -> None:
         console.print(f"[bold yellow]Напоминание:[/bold yellow] {message}")
@@ -324,16 +333,24 @@ def slash_command(text: str) -> bool:
     # /agenda day
     if text.startswith("/agenda"):
         arg = text.replace("/agenda", "").strip().lower() or "today"
-        day = arg
-        if day == "today":
-            date_str = datetime.now().date().isoformat()
-        elif day == "tomorrow":
-            date_str = (datetime.now() + timedelta(days=1)).date().isoformat()
+        tz = _local_tz()
+        if arg == "today":
+            target_date = datetime.now(tz=tz).date()
+        elif arg == "tomorrow":
+            target_date = (datetime.now(tz=tz) + timedelta(days=1)).date()
         else:
-            date_str = day
-        events = [e for e in store.list_events(owner=None) if e["start"].startswith(date_str)]
+            try:
+                target_date = datetime.fromisoformat(arg).date()
+            except Exception:
+                console.print("[red]Неверная дата[/red]")
+                return True
+        events = [
+            e
+            for e in store.list_events(owner=None)
+            if datetime.fromisoformat(e["start"]).astimezone(tz).date() == target_date
+        ]
         if not events:
-            console.print(f"[yellow]Событий на {date_str} нет.[/yellow]")
+            console.print(f"[yellow]Событий на {target_date.isoformat()} нет.[/yellow]")
         else:
             for e in events:
                 console.print(
@@ -424,23 +441,22 @@ def process_free_text(user_text: str) -> None:
         return
 
     # Build system prompt with current timestamps for relative examples
-    now_iso = datetime.now().replace(microsecond=0).isoformat()
+    tz = _local_tz()
+    now = datetime.now(tz=tz)
+    now_iso = now.replace(microsecond=0).isoformat()
     tpl = Template(SYSTEM_PROMPT_TPL)
     sys_prompt = tpl.substitute(
         now_iso=now_iso,
         tomorrow_1800=(
-            datetime.now()
-            .replace(hour=18, minute=0, second=0, microsecond=0)
+            now.replace(hour=18, minute=0, second=0, microsecond=0)
             + timedelta(days=1)
         ).isoformat(),
         after_tomorrow_0930=(
-            datetime.now()
-            .replace(hour=9, minute=30, second=0, microsecond=0)
+            now.replace(hour=9, minute=30, second=0, microsecond=0)
             + timedelta(days=2)
         ).isoformat(),
         tomorrow_0900=(
-            datetime.now()
-            .replace(hour=9, minute=0, second=0, microsecond=0)
+            now.replace(hour=9, minute=0, second=0, microsecond=0)
             + timedelta(days=1)
         ).isoformat(),
     )

--- a/db.py
+++ b/db.py
@@ -8,7 +8,9 @@ creating all tables, indexes and the FTS5 search table.
 from __future__ import annotations
 
 import sqlite3
+from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 
 DB_PATH = Path("data") / "jarvis.db"
@@ -64,6 +66,40 @@ def init_db() -> None:
             """
         )
         conn.commit()
+        migrate_times_to_utc(conn)
+
+
+def _to_utc(s: str) -> str:
+    try:
+        dt = datetime.fromisoformat(s)
+    except Exception:
+        return s
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=ZoneInfo("UTC"))
+    return dt.astimezone(ZoneInfo("UTC")).isoformat()
+
+
+def migrate_times_to_utc(conn: sqlite3.Connection) -> None:
+    """Ensure all stored timestamps are normalised to UTC."""
+    tables = {
+        "tasks": ["due", "created_at"],
+        "events": ["start", "created_at"],
+        "reminders": ["at", "created_at"],
+    }
+    for table, cols in tables.items():
+        rows = conn.execute(f"SELECT id, {', '.join(cols)} FROM {table}").fetchall()
+        for row in rows:
+            for col in cols:
+                val = row[col]
+                if not val:
+                    continue
+                utc_val = _to_utc(val)
+                if utc_val != val:
+                    conn.execute(
+                        f"UPDATE {table} SET {col} = ? WHERE id = ?",
+                        (utc_val, row["id"]),
+                    )
+    conn.commit()
 
 
 # Ensure tables exist when the module is imported

--- a/store.py
+++ b/store.py
@@ -13,6 +13,7 @@ search facility.
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 from typing import Dict, List, Optional
 from uuid import uuid4
 
@@ -39,11 +40,24 @@ def add_task(
     owner: Optional[int] = None,
 ) -> Dict[str, object]:
     task_id = str(uuid4())
-    created_at = datetime.now().isoformat(timespec="seconds")
+    try:
+        created_at_dt = datetime.now(tz=ZoneInfo("local"))
+    except Exception:
+        created_at_dt = datetime.now().astimezone()
+    created_at = created_at_dt.astimezone(ZoneInfo("UTC")).isoformat(timespec="seconds")
     with get_conn() as conn:
         conn.execute(
             "INSERT INTO tasks (id, text, due, done, owner, created_at) VALUES (?,?,?,?,?,?)",
-            (task_id, text, due_iso, 0, owner, created_at),
+            (
+                task_id,
+                text,
+                datetime.fromisoformat(due_iso).astimezone(ZoneInfo("UTC")).isoformat()
+                if due_iso
+                else None,
+                0,
+                owner,
+                created_at,
+            ),
         )
         conn.execute(
             "INSERT INTO search_index (id, type, content, owner) VALUES (?,?,?,?)",
@@ -52,7 +66,9 @@ def add_task(
     return {
         "id": task_id,
         "text": text,
-        "due": due_iso,
+        "due": datetime.fromisoformat(due_iso).astimezone(ZoneInfo("UTC")).isoformat()
+        if due_iso
+        else None,
         "done": False,
         "owner": owner,
         "created_at": created_at,
@@ -99,9 +115,11 @@ def snooze_task(
     if not task:
         return None
     base = (
-        datetime.fromisoformat(task["due"]) if task.get("due") else datetime.now()
+        datetime.fromisoformat(task["due"]) if task.get("due") else datetime.now(tz=ZoneInfo("UTC"))
     )
-    new_due = (base + timedelta(minutes=minutes)).replace(microsecond=0).isoformat()
+    new_due = (
+        base + timedelta(minutes=minutes)
+    ).replace(microsecond=0).astimezone(ZoneInfo("UTC")).isoformat()
     with get_conn() as conn:
         conn.execute("UPDATE tasks SET due = ? WHERE id = ?", (new_due, task["id"]))
     task["due"] = new_due
@@ -120,14 +138,25 @@ def add_event(
     owner: Optional[int] = None,
 ) -> Dict[str, object]:
     event_id = str(uuid4())
-    created_at = datetime.now().isoformat(timespec="seconds")
+    try:
+        created_at_dt = datetime.now(tz=ZoneInfo("local"))
+    except Exception:
+        created_at_dt = datetime.now().astimezone()
+    created_at = created_at_dt.astimezone(ZoneInfo("UTC")).isoformat(timespec="seconds")
     with get_conn() as conn:
         conn.execute(
             """
             INSERT INTO events (id, title, start, duration_min, owner, created_at)
             VALUES (?,?,?,?,?,?)
             """,
-            (event_id, title, start_iso, int(duration_min), owner, created_at),
+            (
+                event_id,
+                title,
+                datetime.fromisoformat(start_iso).astimezone(ZoneInfo("UTC")).isoformat(),
+                int(duration_min),
+                owner,
+                created_at,
+            ),
         )
         conn.execute(
             "INSERT INTO search_index (id, type, content, owner) VALUES (?,?,?,?)",
@@ -136,7 +165,7 @@ def add_event(
     return {
         "id": event_id,
         "title": title,
-        "start": start_iso,
+        "start": datetime.fromisoformat(start_iso).astimezone(ZoneInfo("UTC")).isoformat(),
         "duration_min": int(duration_min),
         "owner": owner,
         "created_at": created_at,
@@ -190,8 +219,20 @@ def update_event_time(
     if not event:
         return None
     with get_conn() as conn:
-        conn.execute("UPDATE events SET start = ? WHERE id = ?", (new_start_iso, event["id"]))
-    event["start"] = new_start_iso
+        conn.execute(
+            "UPDATE events SET start = ? WHERE id = ?",
+            (
+                datetime.fromisoformat(new_start_iso)
+                .astimezone(ZoneInfo("UTC"))
+                .isoformat(),
+                event["id"],
+            ),
+        )
+    event["start"] = (
+        datetime.fromisoformat(new_start_iso)
+        .astimezone(ZoneInfo("UTC"))
+        .isoformat()
+    )
     return event
 
 
@@ -217,7 +258,9 @@ def snooze_event(
     if not event:
         return None
     base = datetime.fromisoformat(event["start"])
-    new_start = (base + timedelta(minutes=minutes)).replace(microsecond=0).isoformat()
+    new_start = (
+        base + timedelta(minutes=minutes)
+    ).replace(microsecond=0).astimezone(ZoneInfo("UTC")).isoformat()
     with get_conn() as conn:
         conn.execute("UPDATE events SET start = ? WHERE id = ?", (new_start, event["id"]))
     event["start"] = new_start
@@ -250,11 +293,21 @@ def add_reminder(
     owner: Optional[int] = None,
 ) -> Dict[str, object]:
     rem_id = str(uuid4())
-    created_at = datetime.now().isoformat(timespec="seconds")
+    try:
+        created_at_dt = datetime.now(tz=ZoneInfo("local"))
+    except Exception:
+        created_at_dt = datetime.now().astimezone()
+    created_at = created_at_dt.astimezone(ZoneInfo("UTC")).isoformat(timespec="seconds")
     with get_conn() as conn:
         conn.execute(
             "INSERT INTO reminders (id, text, at, owner, created_at) VALUES (?,?,?,?,?)",
-            (rem_id, text, at_iso, owner, created_at),
+            (
+                rem_id,
+                text,
+                datetime.fromisoformat(at_iso).astimezone(ZoneInfo("UTC")).isoformat(),
+                owner,
+                created_at,
+            ),
         )
         conn.execute(
             "INSERT INTO search_index (id, type, content, owner) VALUES (?,?,?,?)",
@@ -263,7 +316,7 @@ def add_reminder(
     return {
         "id": rem_id,
         "text": text,
-        "at": at_iso,
+        "at": datetime.fromisoformat(at_iso).astimezone(ZoneInfo("UTC")).isoformat(),
         "owner": owner,
         "created_at": created_at,
     }
@@ -300,7 +353,9 @@ def snooze_reminder(
     if not rem:
         return None
     base = datetime.fromisoformat(rem["at"])
-    new_at = (base + timedelta(minutes=minutes)).replace(microsecond=0).isoformat()
+    new_at = (
+        base + timedelta(minutes=minutes)
+    ).replace(microsecond=0).astimezone(ZoneInfo("UTC")).isoformat()
     with get_conn() as conn:
         conn.execute("UPDATE reminders SET at = ? WHERE id = ?", (new_at, rem["id"]))
     rem["at"] = new_at

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -19,6 +19,9 @@ class DummyMessage:
 @pytest.fixture
 def bot_module(monkeypatch):
     monkeypatch.setenv("TELEGRAM_TOKEN", "123:ABC")
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("STT_PROVIDER", "openai")
     import bot
     importlib.reload(bot)
     return bot

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,12 +1,12 @@
 import store
+import db
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 
 def setup_store(tmp_path, monkeypatch):
-    monkeypatch.setattr(store, "DATA_DIR", tmp_path)
-    monkeypatch.setattr(store, "TASKS_PATH", tmp_path / "tasks.json")
-    monkeypatch.setattr(store, "EVENTS_PATH", tmp_path / "events.json")
-    monkeypatch.setattr(store, "REMINDERS_PATH", tmp_path / "reminders.json")
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "jarvis.db")
+    db.init_db()
 
 
 def test_tasks_flow(tmp_path, monkeypatch):
@@ -19,12 +19,14 @@ def test_tasks_flow(tmp_path, monkeypatch):
 
 def test_events_and_reminders(tmp_path, monkeypatch):
     setup_store(tmp_path, monkeypatch)
-    start = datetime.now().replace(microsecond=0).isoformat()
+    start = datetime.now(tz=ZoneInfo("UTC")).replace(microsecond=0).isoformat()
     ev = store.add_event("meet", start, 30, owner=1)
     assert store.snooze_event(ev["id"][:8], 10, owner=1)["start"]
     deleted = store.delete_event(ev["id"][:8], owner=1)
     assert deleted and deleted["id"] == ev["id"]
-    at = (datetime.now() + timedelta(minutes=5)).replace(microsecond=0).isoformat()
+    at = (
+        datetime.now(tz=ZoneInfo("UTC")) + timedelta(minutes=5)
+    ).replace(microsecond=0).isoformat()
     rem = store.add_reminder("call", at, owner=1)
     assert store.list_reminders(owner=1) == [rem]
     assert store.snooze_reminder(rem["id"][:8], 5, owner=1)["at"]

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -19,6 +19,7 @@ def test_pick_provider(monkeypatch, tmp_path):
         m.setenv("STT_PROVIDER", "auto")
         m.delenv("VOSK_MODEL_DIR", raising=False)
         m.setenv("OPENAI_API_KEY", "x")
+        m.setattr(stt.STT, "_ping_openai", lambda self: True)
         assert stt.STT().provider_in_use() == "openai"
 
 

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,34 @@
+import time
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import importlib
+
+import db
+import store
+
+
+def setup_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "jarvis.db")
+    db.init_db()
+
+
+def test_store_converts_to_utc(tmp_path, monkeypatch):
+    setup_db(tmp_path, monkeypatch)
+    local_due = datetime(2024, 1, 1, 12, tzinfo=ZoneInfo("Europe/Moscow"))
+    task = store.add_task("tz", local_due.isoformat(), owner=1)
+    assert task["due"] == local_due.astimezone(ZoneInfo("UTC")).isoformat()
+    assert task["created_at"].endswith("+00:00")
+
+
+def test_human_respects_timezone(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    cli = importlib.reload(importlib.import_module("cli"))
+    dt = datetime(2024, 1, 1, 12, tzinfo=ZoneInfo("UTC")).isoformat()
+    monkeypatch.setenv("TZ", "UTC")
+    time.tzset()
+    assert "12:00" in cli._human(dt)
+    monkeypatch.setenv("TZ", "Europe/Moscow")
+    time.tzset()
+    assert "15:00" in cli._human(dt)


### PR DESCRIPTION
## Summary
- Store timestamps in UTC using timezone-aware datetimes
- Normalize existing DB records to UTC
- Format and schedule bot/CLI times in the user's local zone
- Add tests for timezone storage and display

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a381c99c388332ac5f834484bf7e33